### PR TITLE
ZEC-24 Implement a GET endpoint for listing products with pagination support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 *.class
 *.jar
 *.sql
+.ecommerce/data/
+SampleDataConfiguration.java
+SampleProductLoader.java

--- a/src/main/java/com/zalando/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/zalando/ecommerce/controller/ProductController.java
@@ -1,0 +1,45 @@
+package com.zalando.ecommerce.controller;
+
+import com.zalando.ecommerce.exception.ProductNotFoundException;
+import com.zalando.ecommerce.model.Product;
+import com.zalando.ecommerce.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/product")
+@RequiredArgsConstructor
+public class ProductController {
+    private final ProductService productService;
+
+    @GetMapping
+    public ResponseEntity<Page<Product>> getAllProducts(@RequestParam("page") int pageCtr,
+                                                        @RequestParam("size") int size){
+        return ResponseEntity.ok(productService.getAllProducts(pageCtr, size));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<Product>> getProductsWithName(@RequestParam("keyword") String productName,
+                                                             @RequestParam("page") int pageCtr,
+                                                        @RequestParam("size") int size){
+        if(productName.contains("+")){
+            productName = productName.replace('+',' ');
+        }
+        return ResponseEntity.ok(productService.getProductsWithName(productName, pageCtr, size));
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getProductById(@PathVariable("id") int productId){
+        System.out.println(productId);
+        try{
+            return ResponseEntity.ok(productService.getProductById(productId));
+        }catch (ProductNotFoundException e){
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/exception/ProductNotFoundException.java
+++ b/src/main/java/com/zalando/ecommerce/exception/ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package com.zalando.ecommerce.exception;
+
+public class ProductNotFoundException extends Exception {
+    public ProductNotFoundException(String message){
+        super(message);
+    }
+    public ProductNotFoundException(){
+        super();
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/repository/ProductRepository.java
+++ b/src/main/java/com/zalando/ecommerce/repository/ProductRepository.java
@@ -2,6 +2,8 @@ package com.zalando.ecommerce.repository;
 
 import com.zalando.ecommerce.model.Product;
 import com.zalando.ecommerce.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +11,5 @@ import java.util.List;
 public interface ProductRepository extends JpaRepository<Product, Integer> {
     List<Product> getAllBySeller(User user);
     List<Product> getProductsByProductNameContainingIgnoreCase(String productName);
+    Page<Product> getProductsByProductNameContainingIgnoreCase(String productName, Pageable pageable);
 }

--- a/src/main/java/com/zalando/ecommerce/service/ProductService.java
+++ b/src/main/java/com/zalando/ecommerce/service/ProductService.java
@@ -1,0 +1,35 @@
+package com.zalando.ecommerce.service;
+
+import com.zalando.ecommerce.exception.ProductNotFoundException;
+import com.zalando.ecommerce.model.Product;
+import com.zalando.ecommerce.model.User;
+import com.zalando.ecommerce.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    public Page<Product> getAllProducts(int pageNum, int size){
+        PageRequest request = PageRequest.of(pageNum, size);
+        return productRepository.findAll(request);
+    }
+
+    public Page<Product> getProductsWithName(String productName, int pageNum, int size){
+        PageRequest request = PageRequest.of(pageNum, size);
+        return productRepository.getProductsByProductNameContainingIgnoreCase(productName, request);
+    }
+
+    public Product getProductById(int productId) throws ProductNotFoundException {
+        Optional<Product> product = productRepository.findById(productId);
+        if (product.isPresent()){
+            return product.get();
+        }else throw new ProductNotFoundException("No product matched the given ID.");
+    }
+}


### PR DESCRIPTION
ZEC-24 Implement a GET endpoint for listing products with pagination support

> https://mauhayannaliza.atlassian.net/browse/ZEC-24?atlOrigin=eyJpIjoiZTQ3ZTRlMmQyNzc4NDIwN2ExOWRmZjhhMjM2NmE1ZmYiLCJwIjoiaiJ9

Tests done using Postman (Note: all below endpoints are authorised by JWT):
- Get product given the product id
> ![Screenshot 2024-01-12 at 1 00 34 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/0ed80f2f-c398-4b01-a092-f5c8ed289adc)
Return 404 when ID does not exist.
> ![Screenshot 2024-01-12 at 1 01 28 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/b172da0b-c0fd-4c6b-b59a-cdc2e356f0ff)


- Get all products with pagination support
> ![Screenshot 2024-01-12 at 1 03 15 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/068ff5cd-ab39-4f2e-897e-8b3d9685cd39)

- Return results when searching with keyword
>  ![Screenshot 2024-01-12 at 1 05 09 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/f4eec05b-2618-4ca9-ae72-bf3270cad510)

Return an empty Page with metadata when no results are found
> ![Screenshot 2024-01-12 at 1 06 07 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/fe84de49-012f-4400-9a8a-54090afb38ab)
