### PR TITLE
ZEC-36 Implement an endpoint to convert a cart into an order, deleting the cart items after purchase.

### DIFF
--- a/src/main/java/com/zalando/ecommerce/controller/OrderController.java
+++ b/src/main/java/com/zalando/ecommerce/controller/OrderController.java
@@ -1,0 +1,61 @@
+package com.zalando.ecommerce.controller;
+
+import com.zalando.ecommerce.exception.EmptyCartException;
+import com.zalando.ecommerce.exception.InsufficientStockException;
+import com.zalando.ecommerce.exception.OrderNotFoundException;
+import com.zalando.ecommerce.exception.UserNotFoundException;
+import com.zalando.ecommerce.model.ErrorResponse;
+import com.zalando.ecommerce.model.Order;
+import com.zalando.ecommerce.service.OrderService;
+import com.zalando.ecommerce.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@Controller
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+    private final UserService userService;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
+    public ResponseEntity<?> createOrder(@AuthenticationPrincipal UserDetails principal){
+        Order order = null;
+        try {
+            order = orderService.createOrder(userService.getUserByEmail(principal.getUsername()));
+        } catch (EmptyCartException | InsufficientStockException | UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
+                    .body(new ErrorResponse(HttpStatus.NOT_ACCEPTABLE, e.getMessage()));
+        }
+        URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{order-id}")
+                .buildAndExpand(order.getOrderId())
+                .toUri();
+        return ResponseEntity.created(uri).body(order);
+    }
+
+    @GetMapping("/{order-id}")
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
+    public ResponseEntity<?> getOrder(@AuthenticationPrincipal UserDetails principal,
+                                      @PathVariable("order-id") int orderId) {
+        try {
+            return ResponseEntity.ok(orderService.getOrderByUserAndId(userService.getUserByEmail(principal.getUsername()), orderId));
+        } catch (OrderNotFoundException | UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
+                    .body(new ErrorResponse(HttpStatus.NOT_ACCEPTABLE, e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/dto/CartResponse.java
+++ b/src/main/java/com/zalando/ecommerce/dto/CartResponse.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Getter @Setter
@@ -12,12 +14,13 @@ import java.util.List;
 public class CartResponse {
     private String message;
     private List<CartItem> cart;
-    private Float totalPrice;
+    private BigDecimal totalPrice;
 
     public CartResponse(String message, List<CartItem> cart) {
         this.message=message;
         this.cart = cart;
-        this.totalPrice = cart.stream()
-                .reduce(0f,(subTotal, cartItem) -> subTotal+cartItem.getQuantity()*cartItem.getProduct().getPrice(), Float::sum);
+        BigDecimal price = cart.stream()
+                .reduce(BigDecimal.ZERO,(subTotal, cartItem) -> subTotal.add(cartItem.getProduct().getPrice().multiply(BigDecimal.valueOf(cartItem.getQuantity()))), BigDecimal::add);
+        this.totalPrice = price.setScale(3, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/zalando/ecommerce/exception/OrderNotFoundException.java
+++ b/src/main/java/com/zalando/ecommerce/exception/OrderNotFoundException.java
@@ -1,0 +1,9 @@
+package com.zalando.ecommerce.exception;
+
+public class OrderNotFoundException extends Exception {
+    public OrderNotFoundException(String message) {
+        super(message);
+    }
+    public OrderNotFoundException() {
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/model/Order.java
+++ b/src/main/java/com/zalando/ecommerce/model/Order.java
@@ -1,10 +1,14 @@
 package com.zalando.ecommerce.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 @Entity @Table(name = "purchase_order")
@@ -25,7 +29,8 @@ public class Order {
     private User customer;
 
     @Column(name = "total_price")
-    private float totalPrice;
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER, pattern="0.###")
+    private BigDecimal totalPrice;
 
     @Column @Enumerated(value = EnumType.ORDINAL)
     private OrderStatus status;
@@ -34,15 +39,16 @@ public class Order {
     private boolean archived;
 
     @OneToMany(mappedBy = "purchaseOrder", cascade = CascadeType.ALL)
-    private Set<OrderItem> orderItems;
+    private List<OrderItem> orderItems;
 
     public Order(User customer, Set<CartItem> cartItemSet, OrderStatus status) {
         this.date = LocalDateTime.now();
         this.customer = customer;
-        this.totalPrice = cartItemSet.stream()
-                .reduce(0f,
-                        (subTotal, cartItem) -> subTotal + cartItem.getQuantity() * cartItem.getProduct().getPrice(),
-                        Float::sum);
+        BigDecimal price = cartItemSet.stream()
+                .reduce(BigDecimal.ZERO.setScale(3),
+                        (subTotal, cartItem) -> subTotal.add(cartItem.getProduct().getPrice().multiply(BigDecimal.valueOf(cartItem.getQuantity()))),
+                        BigDecimal::add);
+        this.totalPrice = price.setScale(3, RoundingMode.HALF_UP);
         this.status = status;
     }
 }

--- a/src/main/java/com/zalando/ecommerce/model/Product.java
+++ b/src/main/java/com/zalando/ecommerce/model/Product.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Setter @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,7 +28,7 @@ public class Product {
     private String description;
 
     @Column
-    private Float price;
+    private BigDecimal price;
 
     @Column(name = "stock_quantity")
     private int stockQuantity;
@@ -38,10 +41,10 @@ public class Product {
     @JoinColumn(name = "seller_id")
     private User seller;
 
-    public Product(String productName, String description, Float price, int stockQuantity, User seller) {
+    public Product(String productName, String description, Float floatPrice, int stockQuantity, User seller) {
         this.productName = productName;
         this.description = description;
-        this.price = price;
+        this.price = BigDecimal.valueOf(floatPrice).setScale(3, RoundingMode.HALF_UP);
         this.stockQuantity = stockQuantity;
         this.seller = seller;
     }

--- a/src/main/java/com/zalando/ecommerce/repository/OrderRepository.java
+++ b/src/main/java/com/zalando/ecommerce/repository/OrderRepository.java
@@ -1,9 +1,13 @@
 package com.zalando.ecommerce.repository;
 
 import com.zalando.ecommerce.model.Order;
+import com.zalando.ecommerce.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Integer> {
+    Optional<Order> getOrderByCustomerAndOrderId(User user, Integer orderId);
 }

--- a/src/main/java/com/zalando/ecommerce/service/ProductService.java
+++ b/src/main/java/com/zalando/ecommerce/service/ProductService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Optional;
 
 @Service
@@ -55,7 +57,7 @@ public class ProductService {
             Product product = foundProduct.get();
             product.setProductName(productRequest.getProductName());
             product.setDescription(productRequest.getDescription());
-            product.setPrice(productRequest.getPrice());
+            product.setPrice(BigDecimal.valueOf(productRequest.getPrice()).setScale(3, RoundingMode.HALF_UP));
             product.setStockQuantity(productRequest.getStockQty());
             return productRepository.save(product);
         }else throw new ProductNotFoundException("No active product matched the given ID for this seller.");

--- a/src/test/java/com/zalando/ecommerce/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/zalando/ecommerce/repository/OrderRepositoryTest.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
@@ -55,6 +57,6 @@ class OrderRepositoryTest {
         assertThat(savedOrder.getDate()).isCloseTo(LocalDateTime.now(), within(1, ChronoUnit.MINUTES));
         assertEquals(OrderStatus.PROCESSING, savedOrder.getStatus());
         assertFalse(savedOrder.isArchived());
-        assertEquals(unitPrice * quantity, savedOrder.getTotalPrice());
+        assertEquals(BigDecimal.valueOf(unitPrice).setScale(3, RoundingMode.HALF_UP).multiply(BigDecimal.valueOf(quantity)), savedOrder.getTotalPrice());
     }
 }

--- a/src/test/java/com/zalando/ecommerce/service/CartItemServiceTest.java
+++ b/src/test/java/com/zalando/ecommerce/service/CartItemServiceTest.java
@@ -19,6 +19,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,14 +46,14 @@ class CartItemServiceTest {
     private CartRequest cartRequest;
     private User user;
     private int quantity;
-    private float price;
+    private BigDecimal price;
     private int productId;
     private Product product;
 
     @BeforeEach
     void setUp() {
         quantity = 10;
-        price = 4f;
+        price = BigDecimal.valueOf(4).setScale(3, RoundingMode.HALF_UP);
         productId = 1;
 
         user = new User(1, "Customer1", "CustomerLastName", "customer@email.com",
@@ -75,7 +77,7 @@ class CartItemServiceTest {
         System.out.println(cartResponse);
         assertThat(cartResponse).isNotNull();
         assertThat(cartResponse.getCart()).isNotEmpty();
-        assertEquals(quantity * price, cartResponse.getTotalPrice());
+        assertEquals(price.multiply(BigDecimal.valueOf(quantity)), cartResponse.getTotalPrice());
     }
 
     @SneakyThrows
@@ -101,7 +103,7 @@ class CartItemServiceTest {
         System.out.println(cartResponse);
         assertThat(cartResponse).isNotNull();
         assertThat(cartResponse.getCart()).isEmpty();
-        assertEquals(0f, cartResponse.getTotalPrice());
+        assertEquals(BigDecimal.ZERO.setScale(3), cartResponse.getTotalPrice());
     }
 
     @SneakyThrows


### PR DESCRIPTION
ZEC-36 Implement an endpoint to convert a cart into an order, deleting the cart items after purchase.

- Changed datatype of prices (unit price, total price) from float to Big Decimal to fix the Cart's and Order's number of decimals in the Total Price.
- Unit tests were modified and all passed.

> https://mauhayannaliza.atlassian.net/browse/ZEC-36?atlOrigin=eyJpIjoiNTQ3ZmNiMTYzZWI3NDc3Mzg3YmRhZGI3NDJmMTU0NzAiLCJwIjoiaiJ9

Value of Cart
![Screenshot 2024-01-22 at 12 25 04 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/8984316a-b2d3-4c78-832d-55968808dd1d)

POST Create an Order from the Cart items
![Screenshot 2024-01-22 at 12 25 53 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/57d840eb-80e3-4523-b5eb-e55bbaf1e936)
Error:
![Screenshot 2024-01-22 at 12 27 05 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/de2b349d-b601-415b-8f26-1c913e24d10c)

GET Existing Order
![Screenshot 2024-01-22 at 12 26 14 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/acc7a48b-b96a-4545-86ae-c2d625749a18)

Error:
![Screenshot 2024-01-22 at 12 28 34 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/c927cab5-1dbf-4432-b7fd-86b4319be5d8)
