### PR TITLE
ZEC-40 Add functionality to update order status (e.g., processing, shipped, delivered)

### DIFF
--- a/src/main/java/com/zalando/ecommerce/controller/OrderController.java
+++ b/src/main/java/com/zalando/ecommerce/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.zalando.ecommerce.controller;
 
+import com.zalando.ecommerce.dto.OrderUpdateRequest;
 import com.zalando.ecommerce.exception.EmptyCartException;
 import com.zalando.ecommerce.exception.InsufficientStockException;
 import com.zalando.ecommerce.exception.OrderNotFoundException;
@@ -14,6 +15,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -69,5 +71,21 @@ public class OrderController {
                     .body(new ErrorResponse(HttpStatus.NOT_ACCEPTABLE, e.getMessage()));
         }
         return ResponseEntity.ok(orderService.getOrdersByStatus(user, status, pageCtr, size));
+    }
+
+    @PutMapping("/{order-id}")
+    @PreAuthorize("hasAnyRole('ADMIN')")
+    public ResponseEntity<?> updateOrder(@AuthenticationPrincipal UserDetails principal,
+                                        @PathVariable("order-id") int orderId,
+                                        @Validated @RequestBody OrderUpdateRequest updateRequest){
+        User user;
+        try {
+            user = userService.getUserByEmail(principal.getUsername());
+            Order order = orderService.updateOrderStatus(user,orderId, updateRequest);
+            return ResponseEntity.ok(order);
+        } catch (UserNotFoundException | OrderNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
+                    .body(new ErrorResponse(HttpStatus.NOT_ACCEPTABLE, e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/zalando/ecommerce/dto/OrderUpdateRequest.java
+++ b/src/main/java/com/zalando/ecommerce/dto/OrderUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.zalando.ecommerce.dto;
+
+import com.zalando.ecommerce.model.OrderStatus;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderUpdateRequest {
+    @NotNull(message = "Order status cannot be null.")
+    private OrderStatus status;
+}

--- a/src/main/java/com/zalando/ecommerce/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zalando/ecommerce/exception/GlobalExceptionHandler.java
@@ -10,8 +10,6 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
@@ -56,6 +54,6 @@ public class GlobalExceptionHandler {
         logger.error(exception.toString());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(exception.getMessage());
+                .body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage()));
     }
 }

--- a/src/main/java/com/zalando/ecommerce/listener/OrderStatusListener.java
+++ b/src/main/java/com/zalando/ecommerce/listener/OrderStatusListener.java
@@ -1,0 +1,21 @@
+package com.zalando.ecommerce.listener;
+
+import com.zalando.ecommerce.model.OrderStatusHistory;
+import com.zalando.ecommerce.model.OrderStatusNotification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderStatusListener implements ApplicationListener<OrderStatusNotification> {
+    private final Logger logger = LoggerFactory.getLogger(OrderStatusListener.class);
+    @Override
+    public void onApplicationEvent(OrderStatusNotification notification) {
+        OrderStatusHistory history = notification.getOrderStatusHistory();
+        logger.info("Status of order " + history.getOrder().getOrderId() +
+                " has been changed from '" + history.getOldStatus() +
+                "' to '" + history.getNewStatus() +
+                "' by user: " + history.getModifier().getEmail());
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/model/OrderStatusHistory.java
+++ b/src/main/java/com/zalando/ecommerce/model/OrderStatusHistory.java
@@ -1,0 +1,54 @@
+package com.zalando.ecommerce.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_status_history")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderStatusHistory {
+    @JsonIgnore
+    @EmbeddedId
+    private OrderStatusHistoryKey id;
+
+    @Column(name = "old_status")
+    @Enumerated
+    private OrderStatus oldStatus;
+
+    @Column(name = "new_status")
+    @Enumerated
+    private OrderStatus newStatus;
+
+    @Column(name = "date_modified")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime dateModified;
+
+    @JsonIgnore
+    @ManyToOne
+    @MapsId("modifierId")
+    @JoinColumn(name = "modifier_id")
+    private User modifier;
+
+    @ManyToOne
+    @MapsId("orderId")
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    public OrderStatusHistory(OrderStatus oldStatus, OrderStatus newStatus,
+                              User modifier, Order order) {
+        this.id = new OrderStatusHistoryKey(modifier.getUserId(), order.getOrderId());
+        this.oldStatus = oldStatus;
+        this.newStatus = newStatus;
+        this.dateModified = LocalDateTime.now();
+        this.order = order;
+        this.modifier = modifier;
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/model/OrderStatusHistoryKey.java
+++ b/src/main/java/com/zalando/ecommerce/model/OrderStatusHistoryKey.java
@@ -1,0 +1,36 @@
+package com.zalando.ecommerce.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderStatusHistoryKey implements Serializable {
+    @Column(name = "modifier_id")
+    private int modifierId;
+
+    @Column(name = "order_id")
+    private int orderId;
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof OrderStatusHistoryKey that)) return false;
+        return getModifierId() == that.getModifierId() && getOrderId() == that.getOrderId();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getModifierId(), getOrderId());
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/model/OrderStatusNotification.java
+++ b/src/main/java/com/zalando/ecommerce/model/OrderStatusNotification.java
@@ -1,0 +1,12 @@
+package com.zalando.ecommerce.model;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+@Getter
+public class OrderStatusNotification extends ApplicationEvent {
+    private final OrderStatusHistory orderStatusHistory;
+    public OrderStatusNotification(Object source, OrderStatusHistory orderStatusHistory) {
+        super(source);
+        this.orderStatusHistory = orderStatusHistory;
+    }
+}

--- a/src/main/java/com/zalando/ecommerce/repository/OrderStatusHistoryRepository.java
+++ b/src/main/java/com/zalando/ecommerce/repository/OrderStatusHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.zalando.ecommerce.repository;
+
+import com.zalando.ecommerce.model.OrderStatusHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderStatusHistoryRepository extends JpaRepository<OrderStatusHistory, Integer> {
+
+}

--- a/src/main/java/com/zalando/ecommerce/service/OrderService.java
+++ b/src/main/java/com/zalando/ecommerce/service/OrderService.java
@@ -1,18 +1,20 @@
 package com.zalando.ecommerce.service;
 
+import com.zalando.ecommerce.dto.OrderUpdateRequest;
 import com.zalando.ecommerce.exception.EmptyCartException;
 import com.zalando.ecommerce.exception.InsufficientStockException;
 import com.zalando.ecommerce.exception.OrderNotFoundException;
 import com.zalando.ecommerce.model.*;
 import com.zalando.ecommerce.repository.OrderItemRepository;
 import com.zalando.ecommerce.repository.OrderRepository;
+import com.zalando.ecommerce.repository.OrderStatusHistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -23,8 +25,10 @@ import java.util.stream.Collectors;
 public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
+    private final OrderStatusHistoryRepository orderStatusHistoryRepository;
     private final CartService cartService;
     private final ProductService productService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Order createOrder(User user) throws EmptyCartException, InsufficientStockException {
@@ -72,5 +76,20 @@ public class OrderService {
     public Page<Order> getOrdersByStatus(User user, OrderStatus orderStatus, int pageNum, int size) {
         PageRequest request = PageRequest.of(pageNum, size);
         return orderRepository.getOrdersByCustomerAndStatus(user, orderStatus, request);
+    }
+
+    @Transactional
+    public Order updateOrderStatus(User user, int orderId, OrderUpdateRequest updateRequest) throws OrderNotFoundException {
+        Optional<Order> orderFound = orderRepository.findById(orderId);
+        if (orderFound.isPresent()){
+            Order order = orderFound.get();
+            OrderStatusHistory history = new OrderStatusHistory(order.getStatus(), updateRequest.getStatus(), user, order);
+            order.setStatus(updateRequest.getStatus());
+            orderStatusHistoryRepository.save(history);
+
+            eventPublisher.publishEvent(new OrderStatusNotification(this, history));
+            return orderRepository.save(order);
+        }else throw new OrderNotFoundException("No order matched the provided ID.");
+
     }
 }

--- a/src/test/java/com/zalando/ecommerce/repository/OrderStatusHistoryRepositoryTest.java
+++ b/src/test/java/com/zalando/ecommerce/repository/OrderStatusHistoryRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.zalando.ecommerce.repository;
+
+import com.zalando.ecommerce.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assertions.*;
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OrderStatusHistoryRepositoryTest {
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private OrderStatusHistoryRepository orderStatusHistoryRepository;
+
+    @Autowired
+    UserRepository userRepository;
+    private User dummyAdmin;
+    private User dummyCustomer;
+    private Order order;
+    private String adminEmail;
+    @BeforeEach
+    void setUp() {
+        adminEmail = "test.admin@email.com";
+        User dummySeller = new User(1, "Jane", "Smith", "test.seller@email.com", "password", Role.SELLER, false, false);
+        dummyCustomer = new User(2, "John", "Smith", "test.buyer@email.com", "password", Role.CUSTOMER, false, false);
+        dummyAdmin = new User(3, "Admin", "Smith", adminEmail, "password", Role.ADMIN, false, false);
+
+        userRepository.save(dummySeller);
+        userRepository.save(dummyCustomer);
+        userRepository.save(dummyAdmin);
+
+        Product product = new Product("Soap", "Mild soap for delicate skin. 200mL", 2.25f, 1000, dummySeller);
+        order = new Order(dummyCustomer, Set.of(new CartItem(10,product, dummyCustomer)), OrderStatus.PROCESSING);
+        orderRepository.save(order);
+    }
+
+    @Test
+    void givenNewOrderStatusHistory_testSave(){
+        OrderStatus oldStatus = OrderStatus.PROCESSING;
+        OrderStatus newStatus = OrderStatus.SHIPPED;
+
+        OrderStatusHistory history = orderStatusHistoryRepository.save(new OrderStatusHistory(oldStatus, newStatus, dummyAdmin, order));
+        assertNotEquals(0, history.getId());
+        assertThat(history.getDateModified()).isCloseTo(LocalDateTime.now(), within(1, ChronoUnit.MINUTES));
+        assertEquals(OrderStatus.PROCESSING, history.getOldStatus());
+        assertEquals(OrderStatus.SHIPPED, history.getNewStatus());
+        assertEquals(adminEmail, history.getModifier().getEmail());
+        assertEquals(BigDecimal.valueOf(22.5).setScale(3), history.getOrder().getTotalPrice());
+    }
+}


### PR DESCRIPTION
ZEC-40 Add functionality to update order status (e.g., processing, shipped, delivered)
- The update endpoint can only be accessed by a user with ADMIN role.
- A basic listener was implemented so that a log info will show up when the order status is changed.

> https://mauhayannaliza.atlassian.net/browse/ZEC-40?atlOrigin=eyJpIjoiMDU5ZmY4ODJlOGQyNDEzMDkyN2Q0ZjMxNjQ1NDg0ZjUiLCJwIjoiaiJ9

![Screenshot 2024-01-24 at 12 37 09 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/7fe02bd9-59d6-4eae-84e3-9a49c5cdae36)

![Screenshot 2024-01-24 at 12 37 31 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/2b36029e-3665-461c-8b63-4872f629028d)

Endpoint accessed by a user with CUSTOMER role.
![Screenshot 2024-01-24 at 12 41 26 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/53d39f10-3aa7-4e72-924b-1a20038daa55)

Log info of the event listener 
![Screenshot 2024-01-24 at 12 47 19 PM](https://github.com/AnnaMauhay/Zalando-E-Commerce/assets/5255871/7b952e15-96db-45a4-aa4b-c630f533e2af)
